### PR TITLE
Update vert.x booster versions.

### DIFF
--- a/circuit-breaker/vert.x/community/vertx-circuit-breaker-community-booster.yaml
+++ b/circuit-breaker/vert.x/community/vertx-circuit-breaker-community-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-circuit-breaker-booster
-gitRef: v9
+gitRef: v10

--- a/circuit-breaker/vert.x/redhat/vertx-circuit-breaker-redhat-booster.yaml
+++ b/circuit-breaker/vert.x/redhat/vertx-circuit-breaker-redhat-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-circuit-breaker-booster-redhat
-gitRef: v4
+gitRef: v5

--- a/configmap/vert.x/community/vertx-configmap-community-booster.yaml
+++ b/configmap/vert.x/community/vertx-configmap-community-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-configmap-booster
-gitRef: v17
+gitRef: v18

--- a/configmap/vert.x/redhat/vertx-configmap-redhat-booster.yaml
+++ b/configmap/vert.x/redhat/vertx-configmap-redhat-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-configmap-booster-redhat
-gitRef: v5
+gitRef: v6

--- a/crud/vert.x/community/vertx-crud-community-booster.yaml
+++ b/crud/vert.x/community/vertx-crud-community-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-crud-booster
-gitRef: v17
+gitRef: v18

--- a/crud/vert.x/community/vertx-crud-community-booster.yaml
+++ b/crud/vert.x/community/vertx-crud-community-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-crud-booster
-gitRef: v16
+gitRef: v17

--- a/crud/vert.x/redhat/vertx-crud-redhat-booster.yaml
+++ b/crud/vert.x/redhat/vertx-crud-redhat-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-crud-booster-redhat
-gitRef: v4
+gitRef: v5

--- a/health-check/vert.x/community/vertx-health-check-community-booster.yaml
+++ b/health-check/vert.x/community/vertx-health-check-community-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-health-checks-booster
-gitRef: v13
+gitRef: v14

--- a/health-check/vert.x/redhat/vertx-health-check-redhat-booster.yaml
+++ b/health-check/vert.x/redhat/vertx-health-check-redhat-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-health-checks-booster-redhat
-gitRef: v4
+gitRef: v5

--- a/rest-http-secured/vert.x/community/vertx-sso-community-booster.yaml
+++ b/rest-http-secured/vert.x/community/vertx-sso-community-booster.yaml
@@ -1,3 +1,3 @@
 githubRepo: openshiftio-vertx-boosters/vertx-secured-http-booster
-gitRef: v10
+gitRef: v11
 supportedDeploymentTypes: zip

--- a/rest-http-secured/vert.x/community/vertx-sso-community-booster.yaml
+++ b/rest-http-secured/vert.x/community/vertx-sso-community-booster.yaml
@@ -1,3 +1,3 @@
 githubRepo: openshiftio-vertx-boosters/vertx-secured-http-booster
-gitRef: v11
+gitRef: v12
 supportedDeploymentTypes: zip

--- a/rest-http-secured/vert.x/redhat/vertx-sso-redhat-booster.yaml
+++ b/rest-http-secured/vert.x/redhat/vertx-sso-redhat-booster.yaml
@@ -1,4 +1,3 @@
-# Use community for now.
-githubRepo: openshiftio-vertx-boosters/vertx-secured-http-booster
-gitRef: v10
+githubRepo: openshiftio-vertx-boosters/vertx-secured-http-booster-redhat
+gitRef: v11
 supportedDeploymentTypes: zip

--- a/rest-http-secured/vert.x/redhat/vertx-sso-redhat-booster.yaml
+++ b/rest-http-secured/vert.x/redhat/vertx-sso-redhat-booster.yaml
@@ -1,3 +1,3 @@
 githubRepo: openshiftio-vertx-boosters/vertx-secured-http-booster-redhat
-gitRef: v11
+gitRef: v12
 supportedDeploymentTypes: zip

--- a/rest-http/vert.x/community/vertx-http-community-booster.yaml
+++ b/rest-http/vert.x/community/vertx-http-community-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-http-booster
-gitRef: v15
+gitRef: v16

--- a/rest-http/vert.x/community/vertx-http-community-booster.yaml
+++ b/rest-http/vert.x/community/vertx-http-community-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-http-booster
-gitRef: v14
+gitRef: v15

--- a/rest-http/vert.x/redhat/vertx-http-redhat-booster.yaml
+++ b/rest-http/vert.x/redhat/vertx-http-redhat-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-http-booster-redhat
-gitRef: v4
+gitRef: v5

--- a/rest-http/vert.x/redhat/vertx-http-redhat-booster.yaml
+++ b/rest-http/vert.x/redhat/vertx-http-redhat-booster.yaml
@@ -1,2 +1,2 @@
 githubRepo: openshiftio-vertx-boosters/vertx-http-booster-redhat
-gitRef: v5
+gitRef: v6


### PR DESCRIPTION
Use CR1 bits - do not merge before CR1 artifacts are made available in a Maven repository.